### PR TITLE
Bug Fixes & Improvements

### DIFF
--- a/src/main/java/com/wolfyscript/jackson/dataformat/hocon/HoconGenerator.java
+++ b/src/main/java/com/wolfyscript/jackson/dataformat/hocon/HoconGenerator.java
@@ -317,6 +317,10 @@ public class HoconGenerator extends GeneratorBase {
     public void writeString(String text) throws IOException {
         _verifyValueWrite(WRITE_STRING);
         _writeValueSeparator(false);
+        if (text == null) {
+            _writeNull();
+            return;
+        }
         _writeString(text);
     }
 
@@ -442,7 +446,11 @@ public class HoconGenerator extends GeneratorBase {
     public void writeNull() throws IOException {
         _verifyValueWrite(WRITE_NULL);
         _writeValueSeparator(false);
-        _writer.write("null");
+        _writeNull();
+    }
+
+    private void _writeNull() throws IOException {
+        writeRaw("null");
     }
 
     @Override

--- a/src/main/java/com/wolfyscript/jackson/dataformat/hocon/HoconGenerator.java
+++ b/src/main/java/com/wolfyscript/jackson/dataformat/hocon/HoconGenerator.java
@@ -339,13 +339,15 @@ public class HoconGenerator extends GeneratorBase {
      * @throws IOException If an I/O error occurs
      */
     protected void _writeString(String text) throws IOException {
-        String renderedKey;
         if (Feature.ALWAYS_QUOTE_STRINGS.enabledIn(_hoconFeatures)) {
-            renderedKey = ConfigImplUtil.renderJsonString(text);
+            _writeQuotedString(text);
         } else {
-            renderedKey = _renderStringUnquotedIfPossible(text);
+            _writeUnquotedStringIfPossible(text);
         }
-        _writer.write(renderedKey);
+    }
+
+    protected void _writeQuotedString(String value) throws IOException {
+        _writer.write(ConfigImplUtil.renderJsonString(value));
     }
 
     /**
@@ -355,30 +357,28 @@ public class HoconGenerator extends GeneratorBase {
      * This method was copied from the renderStringUnquotedIfPossible function in {@link ConfigImplUtil}!
      *
      * @param s The value to write.
-     * @return The rendered String
      * @see ConfigImplUtil ConfigImplUtil#renderStringUnquotedIfPossible(String)
      */
-    protected String _renderStringUnquotedIfPossible(String s) {
-        if (s.length() == 0) {
-            return ConfigImplUtil.renderJsonString(s);
-        } else {
+    protected void _writeUnquotedStringIfPossible(String s) throws IOException {
+        if (s.length() > 0) {
             int first = s.codePointAt(0);
             if (!Character.isDigit(first) && first != 45) {
                 if (!s.startsWith("include") && !s.startsWith("true") && !s.startsWith("false") && !s.startsWith("null") && !s.contains("//")) {
                     for (int i = 0; i < s.length(); ++i) {
                         char c = s.charAt(i);
                         if (!Character.isLetter(c) && !Character.isDigit(c) && c != '-') {
-                            return ConfigImplUtil.renderJsonString(s);
+                            _writeQuotedString(s);
+                            return;
                         }
                     }
-                    return s;
-                } else {
-                    return ConfigImplUtil.renderJsonString(s);
+                    _writer.write(s);
+                    return;
                 }
-            } else {
-                return ConfigImplUtil.renderJsonString(s);
+                _writeQuotedString(s);
+                return;
             }
         }
+        _writeQuotedString(s);
     }
 
     @Override


### PR DESCRIPTION
* Fixed - null Strings cannot be written using the generator
* Improved HoconGenerator#writeString
  * Added internal HoconGenerator#_writeQuotedString
  * HoconGenerator#_writeUnquotedStringIfPossible no longer returns the text, but writes it directly.
* Implemented WRITE_NUMBERS_AS_STRINGS and QUOTE_NON_NUMERIC_NUMBERS features