### PR TITLE
Keep track of current value in ParserContext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.wolfyscript</groupId>
   <artifactId>jackson-dataformat-hocon</artifactId>
-  <version>2.0-SNAPSHOT</version>
+  <version>2.1-SNAPSHOT</version>
   <name>HOCON support for Jackson</name>
   <description>HOCON dataformat implementation for Jackson</description>
   <url>https://github.com/jclawson/jackson-dataformat-hocon</url>

--- a/src/main/java/com/wolfyscript/jackson/dataformat/hocon/HoconNodeCursor.java
+++ b/src/main/java/com/wolfyscript/jackson/dataformat/hocon/HoconNodeCursor.java
@@ -51,7 +51,6 @@ public abstract class HoconNodeCursor extends JsonStreamContext {
 
     @Override
     public void setCurrentValue(java.lang.Object v) {
-        System.out.println("Set " + constructPath() + " >> " + (v == null ? null : v.getClass()));
         this._currentValue = v;
     }
 

--- a/src/test/java/com/wolfyscript/jackson/dataformat/hocon/parser/HoconTreeTraversingParserTest.java
+++ b/src/test/java/com/wolfyscript/jackson/dataformat/hocon/parser/HoconTreeTraversingParserTest.java
@@ -1,18 +1,17 @@
 package com.wolfyscript.jackson.dataformat.hocon.parser;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.wolfyscript.jackson.dataformat.hocon.HoconFactory;
-import java.nio.charset.StandardCharsets;
-import org.junit.Assert;
-import org.junit.Test;
-
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.wolfyscript.jackson.dataformat.hocon.HoconMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Scanner;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class HoconTreeTraversingParserTest {
 
@@ -42,50 +41,50 @@ public class HoconTreeTraversingParserTest {
 
 	@Test
 	public void testUrl() throws IOException {
-		ObjectMapper mapper = new ObjectMapper(new HoconFactory());
+		HoconMapper mapper = new HoconMapper();;
 		Configuration c = mapper.readValue(url("test.conf"), Configuration.class);
 		assertConf(c);
 	}
 
 	@Test
 	public void testStream() throws IOException {
-		ObjectMapper mapper = new ObjectMapper(new HoconFactory());
+		HoconMapper mapper = new HoconMapper();;
 		Configuration c = mapper.readValue(stream("test.conf"), Configuration.class);
 		assertConf(c);
 	}
 
 	@Test
 	public void testReader() throws IOException {
-		ObjectMapper mapper = new ObjectMapper(new HoconFactory());
+		HoconMapper mapper = new HoconMapper();;
 		Configuration c = mapper.readValue(reader(stream("test.conf")), Configuration.class);
 		assertConf(c);
 	}
 
 	@Test
 	public void testString() throws IOException {
-		ObjectMapper mapper = new ObjectMapper(new HoconFactory());
+		HoconMapper mapper = new HoconMapper();;
 		Configuration c = mapper.readValue(stream("test.conf"), Configuration.class);
 		assertConf(c);
 	}
 
 	@Test
 	public void testSubstitution() throws IOException {
-		ObjectMapper mapper = new ObjectMapper(new HoconFactory());
-		Map<String, String> map = mapper.readValue(stream("test-substitution.conf"), Map.class);
+		HoconMapper mapper = new HoconMapper();;
+		Map<String, String> map = mapper.readValue(stream("test-substitution.conf"), new TypeReference<Map<String, String>>() {});
 		Assert.assertEquals("This value ", map.get("foo"));
 		Assert.assertEquals("This value  commes from foo", map.get("bar"));
 	}
 
 	@Test
 	public void testInclusionUrl() throws IOException {
-		ObjectMapper mapper = new ObjectMapper(new HoconFactory());
+		HoconMapper mapper = new HoconMapper();;
 		Configuration c = mapper.readValue(url("test-inclusion.conf"), Configuration.class);
 		assertConf(c);
 	}
 
 	@Test
 	public void testInclusionStreamFails() throws IOException {
-		ObjectMapper mapper = new ObjectMapper(new HoconFactory());
+		HoconMapper mapper = new HoconMapper();
 		Configuration c = mapper.readValue(stream("test-inclusion.conf"), Configuration.class);
 		// inclusion will not work with Stream
 		Assert.assertNull(c.something);


### PR DESCRIPTION
* Added _currentValue and rewritten HoconNodeCursor behaviour to match this change.
* Updated HoconTreeTraversingParser to the new HoconNodeCursor behaviour.
* Upgraded version to 2.1-SNAPSHOT